### PR TITLE
issue 29: If the execution is < 1ms then global > 100 %

### DIFF
--- a/Bench.php
+++ b/Bench.php
@@ -266,6 +266,8 @@ class Bench implements Iterator, \Countable
             return [];
         }
 
+        $runningMarks = $this->pause();
+
         $max = $this->getLongest()->diff();
         $out = [];
 
@@ -286,6 +288,8 @@ class Bench implements Iterator, \Countable
                 self::STAT_POURCENT => $pourcent
             ];
         }
+
+        $this->resume($runningMarks);
 
         return $out;
     }
@@ -308,6 +312,41 @@ class Bench implements Iterator, \Countable
         }
 
         return $outMark;
+    }
+
+    /**
+     * Pause all marks.
+     *
+     * @return  array
+     */
+    public function pause()
+    {
+        $runningMarks = [];
+
+        foreach ($this as $mark) {
+            if (true === $mark->isRunning() && false === $mark->isPause()) {
+                $runningMarks[] = $mark;
+            }
+        }
+
+        foreach ($runningMarks as $mark) {
+            $mark->pause();
+        }
+
+        return $runningMarks;
+    }
+
+    /**
+     * Resume all marks.
+     *
+     * @param   array  $runningMarks    The marks to resume.
+     * @return  void
+     */
+    public function resume($runningMarks)
+    {
+        foreach ($runningMarks as $mark) {
+            $mark->start();
+        }
     }
 
     /**


### PR DESCRIPTION
fix #29 

Moreover, test pause/resume abilities
```php
<?php

require __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';

use Hoa\Bench;


$tab = \SplFixedArray::fromArray(['Gg', 'est', 'le', 'plus', 'beau']);

$bench = new Bench();

$bench->one->start();
$bench->oneBis->start();

for($i=0;$i<$tab->count();$i++){

    echo $tab[$i];

}

$bench->one->stop();
$bench->oneBis->pause();


$bench->two->start();

//le foreach

foreach($tab as $value){

    echo $value;
}

$bench->two->stop();


echo $bench;


$bench->three->start();

//le foreach

foreach($tab as $value){

    echo $value;
}

$bench->three->stop();


echo $bench;
```

```
Ggestleplusbeau
__global__  ||||||||||||||||||||||||||||||||||||||||||||||||||||     0ms, 100.0%
one         |||||||||||                                              0ms,  20.7%
oneBis      |||||||||||||||||||||||||||||||||                        0ms,  63.2%
two         |||                                                      0ms,   6.6%
three       ||                                                       0ms,   4.4%
```